### PR TITLE
Fix incorrect usage of fullbackup in example config.

### DIFF
--- a/jobs/example-job.conf
+++ b/jobs/example-job.conf
@@ -3,12 +3,12 @@
 
 $jobName = "Test Job: My Super Fantastic VM";
 
-# $fullBackup:
+# $fullbackup:
 # if true uuids included in @Selection array are uuids of VM Excluded from Backup.
 # If false uuids included in @Selected array are uuids of VM to backup.
 # In case of selective job, Guests are backed up in the order specified in the array.
 
-$fullBackup = false;
+$fullbackup = false;
 
 # @Selected:
 # Array of Selected Virtual Machines


### PR DESCRIPTION
The example file does not define the same property as checked on.
fullBackup doesn't match the value checked in xenbackup.pl
if ($fullbackup eq true)